### PR TITLE
feat: blueprint copy CLI (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 crucible – ideation space.
+
+## Usage
+
+List available blueprint prompts and copy one to the macOS clipboard:
+
+```bash
+./cru blueprint
+```

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,6 @@
 # TODO
 
-- [ ] Add a way of copying a prompt from the cli, by choosing a blueprint, and getting a high level overview of prompts (so we can select which we want, e.g. 003_codex_expert_implementer.md). We can use `pbcopy` (assume we are on mac)
+- [x] Add a way of copying a prompt from the cli, by choosing a blueprint, and getting a high level overview of prompts (so we can select which we want, e.g. 003_codex_expert_implementer.md). We can use `pbcopy` (assume we are on mac)
 - [ ] Implement real AI model integrations
 - [ ] Expand prompt generation logic
 - [ ] Flesh out brainstorming algorithms

--- a/cru
+++ b/cru
@@ -1,1 +1,10 @@
-# TODO: implement
+#!/usr/bin/env python3
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parent / "src"))
+
+from cli import main
+
+if __name__ == "__main__":
+    main()

--- a/docs/design-blueprint-copy.md
+++ b/docs/design-blueprint-copy.md
@@ -1,0 +1,20 @@
+# Blueprint Copy CLI
+
+## Rationale
+The first TODO item requests an easy way to copy any of the blueprint prompts from the command line. A lightweight interactive command keeps things simple while avoiding extra dependencies. The command lists available markdown files in `blueprints/`, shows a preview of each, and copies the chosen file to the clipboard via macOS `pbcopy`.
+
+## Approach
+- Extend `src/cli.py` with an `argparse` based CLI.
+- Add a `blueprint` subcommand that:
+  1. Lists blueprint filenames with the first line of text as a preview.
+  2. Prompts the user to select one by number.
+  3. Pipes the file contents to `pbcopy` using `subprocess.run`.
+- The helper functions `list_blueprints()` and `copy_blueprint()` are unit tested directly. `subprocess.run` is mocked so tests remain platform independent.
+- A small wrapper script `cru` imports and executes `cli.main()` so the command can be run as `./cru blueprint`.
+
+## Alternatives Considered
+- Using a third‑party clipboard library (e.g. `pyperclip`). This was avoided to keep dependencies minimal.
+- Implementing a fully interactive TUI. Overkill for the current scope.
+
+## Risks
+- `pbcopy` only exists on macOS. The command gracefully fails if it is missing, informing the user.

--- a/src/cli.py
+++ b/src/cli.py
@@ -1,10 +1,71 @@
+"""Project CLI entry point."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+from typing import Callable, Iterable
+
 from crucible.orchestrator import Orchestrator
 
 
-def main():
-    orch = Orchestrator()
-    orch.bus.emit("generate_prompt", {"topic": "demo"})
+BLUEPRINT_DIR = Path(__file__).resolve().parents[1] / "blueprints"
 
 
-if __name__ == "__main__":
+def list_blueprints(directory: Path = BLUEPRINT_DIR) -> list[tuple[str, str]]:
+    """Return available blueprints and a one line preview."""
+    blueprints: list[tuple[str, str]] = []
+    for path in sorted(directory.glob("*.md")):
+        first_line = path.read_text().strip().splitlines()[0]
+        blueprints.append((path.name, first_line))
+    return blueprints
+
+
+def copy_blueprint(
+    name: str,
+    *,
+    directory: Path = BLUEPRINT_DIR,
+    run: Callable[..., subprocess.CompletedProcess | None] = subprocess.run,
+) -> None:
+    """Copy blueprint content to clipboard using pbcopy."""
+    path = directory / name
+    if not path.exists():
+        raise FileNotFoundError(name)
+    try:
+        run(["pbcopy"], input=path.read_bytes(), check=False)
+    except FileNotFoundError:
+        print("pbcopy not found; unable to copy to clipboard")
+
+
+def blueprint_command() -> None:
+    """Interactive blueprint chooser."""
+    blueprints = list_blueprints()
+    for idx, (name, preview) in enumerate(blueprints, 1):
+        print(f"{idx}: {name} - {preview}")
+    choice = input("Select blueprint number: ")
+    try:
+        index = int(choice) - 1
+        selected = blueprints[index][0]
+    except (ValueError, IndexError):
+        print("Invalid selection")
+        return
+    copy_blueprint(selected)
+    print(f"Copied {selected} to clipboard")
+
+
+def main(argv: Iterable[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Crucible CLI")
+    sub = parser.add_subparsers(dest="command")
+    sub.add_parser("blueprint", help="Copy a blueprint prompt to clipboard")
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "blueprint":
+        blueprint_command()
+    else:
+        orch = Orchestrator()
+        orch.bus.emit("generate_prompt", {"topic": "demo"})
+
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
     main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,31 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from cli import list_blueprints, copy_blueprint
+
+
+def test_list_blueprints():
+    blueprints = list_blueprints(Path(__file__).resolve().parents[1] / "blueprints")
+    names = [bp[0] for bp in blueprints]
+    assert "003_codex_expert_implementer.md" in names
+
+
+def test_copy_blueprint(monkeypatch, tmp_path):
+    called = {}
+
+    def fake_run(cmd, *, input, check):
+        called["cmd"] = cmd
+        called["input"] = input
+        called["check"] = check
+
+    blueprint = "0_domain_expert_persona.md"
+    copy_blueprint(
+        blueprint,
+        directory=Path(__file__).resolve().parents[1] / "blueprints",
+        run=fake_run,
+    )
+    assert called["cmd"] == ["pbcopy"]
+    assert len(called["input"]) > 0
+


### PR DESCRIPTION
## Summary
- implement interactive blueprint copy command
- document usage and design
- add regression tests

## Design Rationale
See `docs/design-blueprint-copy.md` for motivation and alternatives considered.

## Risks
- `pbcopy` may be missing on non-macOS systems; the CLI warns instead of failing.

## Testing
- `ruff check .`
- `mypy src`
- `pytest -q`
- `pre-commit run --all-files` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ad86344a48323abbfb6dee1419150