### PR TITLE
feat: integrate openai model (staff-grade)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ List available blueprint prompts and copy one to the macOS clipboard:
 ```bash
 ./cru blueprint
 ```
+
+`AIModel` uses the OpenAI API. Set an `OPENAI_API_KEY` environment variable
+before running features that query the model.

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 # TODO
 
 - [x] Add a way of copying a prompt from the cli, by choosing a blueprint, and getting a high level overview of prompts (so we can select which we want, e.g. 003_codex_expert_implementer.md). We can use `pbcopy` (assume we are on mac)
-- [ ] Implement real AI model integrations
+- [x] Implement real AI model integrations
 - [ ] Expand prompt generation logic
 - [ ] Flesh out brainstorming algorithms
 - [ ] Implement summarization techniques

--- a/docs/design-ai-model-integration.md
+++ b/docs/design-ai-model-integration.md
@@ -1,0 +1,26 @@
+# AI Model Integration
+
+## Rationale
+The skeleton currently stubs out `AIModel` with a print statement. The next step
+is to integrate a real model so brainstorming components can produce useful
+results. OpenAI's API is a convenient default because it is widely available and
+easy to mock in tests.
+
+## Approach
+- Implement `AIModel` in `src/crucible/ai.py` using the `openai` package.
+- API key is read from ``OPENAI_API_KEY`` unless explicitly provided.
+- `query()` sends the prompt to `ChatCompletion.create` and returns the
+  assistant message text.
+- The dependency is optional; if `openai` is not installed a clear
+  `RuntimeError` is raised.
+- Tests mock the `openai` module to avoid network calls.
+
+## Alternatives Considered
+- Supporting multiple providers via a plugin system. Premature for the current
+  scope.
+- Using command line flags or config files for API settings. Environment
+  variables keep things simple for now.
+
+## Risks
+- API failures or rate limits could break the CLI; higher levels should handle
+  exceptions gracefully (future work).

--- a/src/crucible/ai.py
+++ b/src/crucible/ai.py
@@ -1,4 +1,33 @@
+"""Simple wrapper around an OpenAI chat model."""
+
+from __future__ import annotations
+
+import os
+
+
 class AIModel:
+    """Query an OpenAI chat completion model."""
+
+    def __init__(self, api_key: str | None = None, model: str = "gpt-3.5-turbo") -> None:
+        try:  # Lazy optional import to keep dependency optional.
+            import openai  # type: ignore
+        except ModuleNotFoundError as exc:  # pragma: no cover - runtime path
+            raise RuntimeError(
+                "openai package is required for AIModel but is not installed"
+            ) from exc
+
+        self._openai = openai
+        self._openai.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        self._model = model
+
     def query(self, prompt: str) -> str:
-        print("todo: integrate AI model")
-        return "ai response"
+        """Return the assistant message for ``prompt``."""
+        response = self._openai.ChatCompletion.create(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return (
+            response["choices"][0]["message"]["content"].strip()
+            if response.get("choices")
+            else ""
+        )

--- a/tests/test_ai_model.py
+++ b/tests/test_ai_model.py
@@ -1,0 +1,35 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+from crucible.ai import AIModel
+
+
+def test_query_uses_openai():
+    # Provide a fake openai module
+    dummy_resp = {"choices": [{"message": {"content": "pong"}}]}
+
+    def create(**kwargs):
+        return dummy_resp
+
+    dummy = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=create)
+    )
+    sys.modules["openai"] = dummy
+
+    model = AIModel(api_key="test-key", model="test")
+    assert model.query("ping") == "pong"
+
+    sys.modules.pop("openai")
+
+
+def test_missing_openai():
+    sys.modules.pop("openai", None)
+    try:
+        AIModel()
+    except RuntimeError as e:
+        assert "openai" in str(e)
+    else:  # pragma: no cover - should not happen
+        assert False

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
-from cli import list_blueprints, copy_blueprint, blueprint_command, MEMORY_FILE
+from cli import list_blueprints, copy_blueprint, blueprint_command
 
 
 def test_list_blueprints():


### PR DESCRIPTION
## Summary
- add AI model wrapper around OpenAI ChatCompletion
- explain approach and rationale in new design doc
- document required OPENAI_API_KEY variable
- add unit tests
- mark TODO item complete

## Design Rationale
The `AIModel` class now imports `openai` lazily and exposes a `query` method that sends prompts to `ChatCompletion`. The API key is read from `OPENAI_API_KEY` by default. Missing dependencies raise a clear `RuntimeError`. Tests inject a fake `openai` module so no network calls occur.

## Risks
- Runtime failures if the OpenAI API is unreachable or rate limited
- Potential dependency version mismatches; mitigated by optional import

## Testing
- `ruff check .`
- `mypy src tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686b08d07c50832383f1b10ae1a3fb50